### PR TITLE
refacto: Split program in several files:

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+
+[*]
+# Unix-style newlines
+end_of_line = lf
+# Always end with an empty new line
+insert_final_newline = true
+# Set default charset to utf-8
+charset = utf-8
+# Indent with 2 spaces
+indent_style = space
+indent_size = 2
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 config.ini
+
+# ignore venv
+**/.venv
+
+# ignore python cache
+**/__pycache__

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -1,0 +1,36 @@
+import logging
+from os import chdir, path
+from subprocess import run, DEVNULL
+from tempfile import TemporaryDirectory
+
+from flask import Blueprint, current_app, jsonify, request
+
+import runner.utils
+
+docker = Blueprint("docker", __name__)
+
+
+@docker.route("/build", methods=["POST"])
+def docker_build():
+    body = request.get_json()
+
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("docker build")
+            chdir(temp_dir)
+            result = run(
+                [current_app.docker, "build", "-t", body["repository"]["name"], "."],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="docker build failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")

--- a/runner/rsync.py
+++ b/runner/rsync.py
@@ -1,0 +1,58 @@
+import logging
+from os import chdir, path
+from subprocess import run, DEVNULL
+from tempfile import TemporaryDirectory
+
+from flask import Blueprint, current_app, jsonify, request
+from werkzeug import utils
+
+import runner.utils
+
+rsync = Blueprint("rsync", __name__)
+
+
+@rsync.route("/rsync", methods=["POST"])
+def route_rsync():
+    body = request.get_json()
+    dest = request.args.get("dest") or body["repository"]["name"]
+    rsync_root = current_app.runner_config.get("rsync", "RSYNC_ROOT", fallback="")
+    if rsync_root:
+        dest = path.join(rsync_root, utils.secure_filename(dest))
+        logging.debug("rsync dest path updated to " + dest)
+
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("rsync " + body["repository"]["name"] + " to " + dest)
+            chdir(temp_dir)
+            if current_app.runner_config.get("rsync", "DELETE", fallback=""):
+                result = run(
+                    [
+                        current_app.rsync,
+                        "-r",
+                        "--exclude=.git",
+                        "--delete-during"
+                        if current_app.runner_config.get("rsync", "DELETE", fallback="")
+                        else "",
+                        ".",
+                        dest,
+                    ],
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+                )
+            else:
+                result = run(
+                    [current_app.rsync, "-r", "--exclude=.git", ".", dest],
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+                )
+            if result.returncode != 0:
+                return jsonify(status="rsync failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")

--- a/runner/terraform.py
+++ b/runner/terraform.py
@@ -1,0 +1,73 @@
+import logging
+from os import chdir
+from subprocess import run, DEVNULL
+from tempfile import TemporaryDirectory
+
+from flask import Blueprint, current_app, jsonify, request
+
+import runner.utils
+
+terraform = Blueprint("terraform", __name__)
+
+
+@terraform.route("/plan", methods=["POST"])
+def terraform_plan():
+    body = request.get_json()
+
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("terraform init")
+            chdir(temp_dir)
+            result = run(
+                [current_app.tf_bin, "init", "-no-color"],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform init failed"), 500
+            result = run(
+                [current_app.tf_bin, "plan", "-no-color"], stdout=None, stderr=None
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform plan failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")
+
+
+@terraform.route("/apply", methods=["POST"])
+def terraform_apply():
+    body = request.get_json()
+    with TemporaryDirectory() as temp_dir:
+        if runner.utils.git_clone(
+            body["repository"]["clone_url"]
+            if current_app.git_protocol == "http"
+            else body["repository"]["ssh_url"],
+            temp_dir,
+        ):
+            logging.info("terraform init")
+            chdir(temp_dir)
+            result = run(
+                [current_app.tf_bin, "init", "-no-color"],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform init failed"), 500
+            result = run(
+                [current_app.tf_bin, "apply", "-auto-approve", "-no-color"],
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+            )
+            if result.returncode != 0:
+                return jsonify(status="terraform apply failed"), 500
+        else:
+            return jsonify(status="git clone failed"), 500
+
+    return jsonify(status="success")

--- a/runner/utils.py
+++ b/runner/utils.py
@@ -1,0 +1,27 @@
+import logging
+from os import chdir
+from subprocess import run, DEVNULL
+
+from flask import current_app
+
+
+def git_clone(src_url, dest_dir):
+    """
+    Clone a remote git repository into a local directory.
+
+    Args:
+        src_url (string): Url used to clone the repo.
+        dest_dir (string): Path to the local directory.
+
+    Returns:
+       (boolean): True if command returns success.
+    """
+
+    logging.info("git clone " + src_url)
+    chdir(dest_dir)
+    clone_result = run(
+        [current_app.git, "clone", src_url, "."],
+        stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+        stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
+    )
+    return clone_result.returncode == 0

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -60,13 +60,7 @@ def git_clone(src_url, dest_dir):
     """
 
     logging.info("git clone " + src_url)
-    if app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False") == True:
-        environ["GIT_SSL_NO_VERIFY"] = "true"
     chdir(dest_dir)
-    if app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False") == True:
-        environ[
-            "GIT_SSH_COMMAND"
-        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
     clone_result = run(
         [app.git, "clone", src_url, "."],
         stdout=None if args.debug else DEVNULL,
@@ -295,6 +289,19 @@ if __name__ == "__main__":
     except:
         logging.error("terraform binary not found or not executable")
         exit(1)
+
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ["GIT_SSL_NO_VERIFY"] = "true"
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ[
+            "GIT_SSH_COMMAND"
+        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
 
     serve(
         app,

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -63,8 +63,8 @@ def git_clone(src_url, dest_dir):
     chdir(dest_dir)
     clone_result = run(
         [app.git, "clone", src_url, "."],
-        stdout=None if args.debug else DEVNULL,
-        stderr=None if args.debug else DEVNULL,
+        stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+        stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
     )
     return clone_result.returncode == 0
 
@@ -139,14 +139,14 @@ def rsync():
                         ".",
                         dest,
                     ],
-                    stdout=None if args.debug else DEVNULL,
-                    stderr=None if args.debug else DEVNULL,
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
                 )
             else:
                 result = run(
                     [app.rsync, "-r", "--exclude=.git", ".", dest],
-                    stdout=None if args.debug else DEVNULL,
-                    stderr=None if args.debug else DEVNULL,
+                    stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                    stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
                 )
             if result.returncode != 0:
                 return jsonify(status="rsync failed"), 500
@@ -171,8 +171,8 @@ def docker_build():
             chdir(temp_dir)
             result = run(
                 [app.docker, "build", "-t", body["repository"]["name"], "."],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="docker build failed"), 500
@@ -197,8 +197,8 @@ def terraform_plan():
             chdir(temp_dir)
             result = run(
                 [app.tf_bin, "init", "-no-color"],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="terraform init failed"), 500
@@ -225,15 +225,15 @@ def terraform_apply():
             chdir(temp_dir)
             result = run(
                 [app.tf_bin, "init", "-no-color"],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="terraform init failed"), 500
             result = run(
                 [app.tf_bin, "apply", "-auto-approve", "-no-color"],
-                stdout=None if args.debug else DEVNULL,
-                stderr=None if args.debug else DEVNULL,
+                stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
+                stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
             if result.returncode != 0:
                 return jsonify(status="terraform apply failed"), 500

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -37,6 +37,8 @@ from flask import Flask, request, jsonify
 from waitress import serve
 from werkzeug import utils
 
+import runner.utils
+
 print("Tea Runner")
 
 # Debug is a command-line option, but most configuration comes from config.ini
@@ -45,28 +47,6 @@ arg_parser.add_argument(
     "-d", "--debug", action="store_true", help="display debugging output while running"
 )
 args = arg_parser.parse_args()
-
-
-def git_clone(src_url, dest_dir):
-    """
-    Clone a remote git repository into a local directory.
-
-    Args:
-        src_url (string): Url used to clone the repo.
-        dest_dir (string): Path to the local directory.
-
-    Returns:
-       (boolean): True if command returns success.
-    """
-
-    logging.info("git clone " + src_url)
-    chdir(dest_dir)
-    clone_result = run(
-        [app.git, "clone", src_url, "."],
-        stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
-        stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
-    )
-    return clone_result.returncode == 0
 
 
 app = Flask(__name__)
@@ -119,7 +99,7 @@ def rsync():
         logging.debug("rsync dest path updated to " + dest)
 
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
@@ -161,7 +141,7 @@ def docker_build():
     body = request.get_json()
 
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
@@ -187,7 +167,7 @@ def terraform_plan():
     body = request.get_json()
 
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
@@ -215,7 +195,7 @@ def terraform_plan():
 def terraform_apply():
     body = request.get_json()
     with TemporaryDirectory() as temp_dir:
-        if git_clone(
+        if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if git_protocol == "http"
             else body["repository"]["ssh_url"],

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -76,14 +76,13 @@ if not access(DOCKER_BIN, X_OK):
     exit(1)
 
 
-def git_clone(src_url, dest_dir, protocol):
+def git_clone(src_url, dest_dir):
     """
     Clone a remote git repository into a local directory.
 
     Args:
         src_url (string): Url used to clone the repo.
         dest_dir (string): Path to the local directory.
-        protocol (string): Protocol to use to clone the repo.
 
     Returns:
        (boolean): True if command returns success.
@@ -160,7 +159,6 @@ def rsync():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("rsync " + body["repository"]["name"] + " to " + dest)
             chdir(temp_dir)
@@ -203,7 +201,6 @@ def docker_build():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("docker build")
             chdir(temp_dir)
@@ -230,7 +227,6 @@ def terraform_plan():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("terraform init")
             chdir(temp_dir)
@@ -259,7 +255,6 @@ def terraform_apply():
             if git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
-            git_protocol,
         ):
             logging.info("terraform init")
             chdir(temp_dir)

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -27,7 +27,7 @@ import logging
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from ipaddress import ip_address, ip_network
-from os import  access, chdir, environ, path, X_OK
+from os import access, chdir, environ, path, X_OK
 from subprocess import run, DEVNULL
 from sys import exit
 from tempfile import TemporaryDirectory

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -28,6 +28,7 @@ from argparse import ArgumentParser
 from configparser import ConfigParser
 from ipaddress import ip_address, ip_network
 from os import access, chdir, environ, path, X_OK
+from shutil import which
 from subprocess import run, DEVNULL
 from sys import exit
 from tempfile import TemporaryDirectory
@@ -36,10 +37,10 @@ from flask import Flask, request, jsonify
 from waitress import serve
 from werkzeug import utils
 
-GIT_BIN = "/usr/bin/git"
-RSYNC_BIN = "/usr/bin/rsync"
-DOCKER_BIN = "/usr/bin/docker"
-TF_BIN = "/usr/bin/terraform"
+GIT_BIN = which("git")
+RSYNC_BIN = which("rsync")
+DOCKER_BIN = which("docker")
+TF_BIN = which("terraform")
 
 print("Tea Runner")
 
@@ -65,14 +66,25 @@ else:
 git_protocol = config.get("runner", "GIT_PROTOCOL", fallback="http")
 logging.info("git protocol is " + git_protocol)
 
-if not access(GIT_BIN, X_OK):
+try:
+    access(GIT_BIN, X_OK)
+except:
     logging.error("git binary not found or not executable")
     exit(1)
-if not access(RSYNC_BIN, X_OK):
+try:
+    access(RSYNC_BIN, X_OK)
+except:
     logging.error("rsync binary not found or not executable")
     exit(1)
-if not access(DOCKER_BIN, X_OK):
+try:
+    access(DOCKER_BIN, X_OK)
+except:
     logging.error("docker binary not found or not executable")
+    exit(1)
+try:
+    access(TF_BIN, X_OK)
+except:
+    logging.error("terraform binary not found or not executable")
     exit(1)
 
 

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -101,7 +101,7 @@ def rsync():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -143,7 +143,7 @@ def docker_build():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -169,7 +169,7 @@ def terraform_plan():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -197,7 +197,7 @@ def terraform_apply():
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
-            if git_protocol == "http"
+            if app.git_protocol == "http"
             else body["repository"]["ssh_url"],
             temp_dir,
         ):
@@ -236,8 +236,8 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
-    git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
-    logging.info("git protocol is " + git_protocol)
+    app.git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
+    logging.info("git protocol is " + app.git_protocol)
 
     logging.info(
         "Limiting requests to: "


### PR DESCRIPTION
In order to improve readability of code, and to ease the addition of new routes, the application is now split in several files:

* `tea_runner.py` contains the main program
* `runner/utils` contains definition of functions (like `git_clone()`)
* `runner/{docker,rsync,terraform}.py` contain the definition of routes. These files define [blueprints](https://flask.palletsprojects.com/en/2.2.x/blueprints/) that are imported in the main program.

In addition to the modularization, this PR contains small enhancements:

* Inclusion of `__pycache__` and `.venv` directories to the list of files ignored by git.
* An additional `.editorconfig` file to helps maintaining consistent coding styles (see [editconfig.org](https://editorconfig.org/) for more information).
* Execution of `black` to improve code style (see [black documentation](https://black.readthedocs.io/en/stable/) for more information).
