### PR TITLE
feat: Move to quart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Flask>=2.1.0
-waitress>=2.1.0
+quart==0.18.3

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -1,0 +1,123 @@
+import logging
+from ipaddress import ip_address, ip_network
+from os import access, environ, X_OK
+from shutil import which
+
+from quart import Quart, request, jsonify
+
+
+def create_app(config):
+    print("Tea Runner")
+    # Configure loglevel
+    if config.getboolean("runner", "DEBUG", fallback="False") == True:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
+        logging.info("Debug logging is on")
+    else:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
+
+    app = Quart(__name__)
+
+    # Configure Quart
+    app.runner_config = config
+    app.git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
+
+    # Check presence of external programs
+    app.docker = which("docker")
+    try:
+        access(app.docker, X_OK)
+    except:
+        logging.error("docker binary not found or not executable")
+        exit(1)
+
+    app.git = which("git")
+    try:
+        access(app.git, X_OK)
+    except:
+        logging.error("git binary not found or not executable")
+        exit(1)
+
+    app.rsync = which("rsync")
+    try:
+        access(app.rsync, X_OK)
+    except:
+        logging.error("rsync binary not found or not executable")
+        exit(1)
+
+    app.tf_bin = which("terraform")
+    try:
+        access(app.tf_bin, X_OK)
+    except:
+        logging.error("terraform binary not found or not executable")
+        exit(1)
+
+    # Set environment variables
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ["GIT_SSL_NO_VERIFY"] = "true"
+    if (
+        app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False")
+        == True
+    ):
+        environ[
+            "GIT_SSH_COMMAND"
+        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
+
+    # Log some informations
+    logging.info("git protocol is " + app.git_protocol)
+    logging.info(
+        "Limiting requests to: "
+        + app.runner_config.get("runner", "ALLOWED_IP_RANGE", fallback="<any>")
+    )
+
+    @app.before_request
+    async def check_authorized():
+        """
+        Only respond to requests from ALLOWED_IP_RANGE if it's configured in config.ini
+        """
+        if app.runner_config.has_option("runner", "ALLOWED_IP_RANGE"):
+            allowed_ip_range = ip_network(
+                app.runner_config["runner"]["ALLOWED_IP_RANGE"]
+            )
+            requesting_ip = ip_address(request.remote_addr)
+            if requesting_ip not in allowed_ip_range:
+                logging.info(
+                    "Dropping request from unauthorized host " + request.remote_addr
+                )
+                return jsonify(status="forbidden"), 403
+            else:
+                logging.info("Request from " + request.remote_addr)
+
+    @app.before_request
+    async def check_media_type():
+        """
+        Only respond requests with Content-Type header of application/json
+        """
+        if (
+            not request.headers.get("Content-Type")
+            .lower()
+            .startswith("application/json")
+        ):
+            logging.error(
+                '"Content-Type: application/json" header missing from request made by '
+                + request.remote_addr
+            )
+            return jsonify(status="unsupported media type"), 415
+
+    @app.route("/test", methods=["POST"])
+    async def test():
+        logging.debug("Content-Type: " + request.headers.get("Content-Type"))
+        logging.debug(await request.get_json(force=True))
+        return jsonify(status="success", sender=request.remote_addr)
+
+    # Register Blueprints
+    from runner.docker import docker as docker_bp
+    from runner.rsync import rsync as rsync_bp
+    from runner.terraform import terraform as terraform_bp
+
+    app.register_blueprint(docker_bp, url_prefix="/docker")
+    app.register_blueprint(rsync_bp)
+    app.register_blueprint(terraform_bp, url_prefix="/terraform")
+
+    return app

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -3,7 +3,7 @@ from os import chdir, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
-from flask import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, jsonify, request
 
 import runner.utils
 
@@ -11,8 +11,8 @@ docker = Blueprint("docker", __name__)
 
 
 @docker.route("/build", methods=["POST"])
-def docker_build():
-    body = request.get_json()
+async def docker_build():
+    body = await request.get_json()
 
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir, getcwd, path
+from os import chdir, getcwd
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 

--- a/runner/docker.py
+++ b/runner/docker.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir, path
+from os import chdir, getcwd, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
@@ -15,6 +15,7 @@ async def docker_build():
     body = await request.get_json()
 
     with TemporaryDirectory() as temp_dir:
+        current_dir = getcwd()
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if current_app.git_protocol == "http"
@@ -28,6 +29,7 @@ async def docker_build():
                 stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
                 stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
             )
+            chdir(current_dir)
             if result.returncode != 0:
                 return jsonify(status="docker build failed"), 500
         else:

--- a/runner/rsync.py
+++ b/runner/rsync.py
@@ -3,7 +3,7 @@ from os import chdir, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
-from flask import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, jsonify, request
 from werkzeug import utils
 
 import runner.utils
@@ -12,8 +12,8 @@ rsync = Blueprint("rsync", __name__)
 
 
 @rsync.route("/rsync", methods=["POST"])
-def route_rsync():
-    body = request.get_json()
+async def route_rsync():
+    body = await request.get_json()
     dest = request.args.get("dest") or body["repository"]["name"]
     rsync_root = current_app.runner_config.get("rsync", "RSYNC_ROOT", fallback="")
     if rsync_root:

--- a/runner/rsync.py
+++ b/runner/rsync.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir, path
+from os import chdir, getcwd, path
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
@@ -21,6 +21,7 @@ async def route_rsync():
         logging.debug("rsync dest path updated to " + dest)
 
     with TemporaryDirectory() as temp_dir:
+        current_dir = getcwd()
         if runner.utils.git_clone(
             body["repository"]["clone_url"]
             if current_app.git_protocol == "http"
@@ -50,6 +51,7 @@ async def route_rsync():
                     stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
                     stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
                 )
+            chdir(current_dir)
             if result.returncode != 0:
                 return jsonify(status="rsync failed"), 500
         else:

--- a/runner/terraform.py
+++ b/runner/terraform.py
@@ -3,7 +3,7 @@ from os import chdir
 from subprocess import run, DEVNULL
 from tempfile import TemporaryDirectory
 
-from flask import Blueprint, current_app, jsonify, request
+from quart import Blueprint, current_app, jsonify, request
 
 import runner.utils
 
@@ -11,8 +11,8 @@ terraform = Blueprint("terraform", __name__)
 
 
 @terraform.route("/plan", methods=["POST"])
-def terraform_plan():
-    body = request.get_json()
+async def terraform_plan():
+    body = await request.get_json()
 
     with TemporaryDirectory() as temp_dir:
         if runner.utils.git_clone(

--- a/runner/utils.py
+++ b/runner/utils.py
@@ -1,5 +1,5 @@
 import logging
-from os import chdir
+from os import chdir, getcwd
 from subprocess import run, DEVNULL
 
 from quart import current_app
@@ -18,10 +18,12 @@ def git_clone(src_url, dest_dir):
     """
 
     logging.info("git clone " + src_url)
+    current_dir = getcwd()
     chdir(dest_dir)
     clone_result = run(
         [current_app.git, "clone", src_url, "."],
         stdout=None if logging.root.level == logging.DEBUG else DEVNULL,
         stderr=None if logging.root.level == logging.DEBUG else DEVNULL,
     )
+    chdir(current_dir)
     return clone_result.returncode == 0

--- a/runner/utils.py
+++ b/runner/utils.py
@@ -2,7 +2,7 @@ import logging
 from os import chdir
 from subprocess import run, DEVNULL
 
-from flask import current_app
+from quart import current_app
 
 
 def git_clone(src_url, dest_dir):

--- a/tea_runner.py
+++ b/tea_runner.py
@@ -23,19 +23,13 @@ Configuration file (config.ini) options:
     # TCP port number used for incoming requests. Defaults to 1706.
 """
 
-import logging
+import asyncio
 from argparse import ArgumentParser
 from configparser import ConfigParser
-from ipaddress import ip_address, ip_network
-from os import access, environ, X_OK
-from shutil import which
-from sys import exit
 
-from quart import Quart, request, jsonify
+from hypercorn.asyncio import Config, serve
 
-import runner.utils
-
-print("Tea Runner")
+import runner
 
 # Debug is a command-line option, but most configuration comes from config.ini
 arg_parser = ArgumentParser()
@@ -44,118 +38,18 @@ arg_parser.add_argument(
 )
 args = arg_parser.parse_args()
 
+quart_config = ConfigParser()
+quart_config.read("config.ini")
+hypercorn_config = Config()
 
-app = Quart(__name__)
+hypercorn_config.bind = (
+    quart_config.get("runner", "LISTEN_IP", fallback="0.0.0.0")
+    + ":"
+    + str(quart_config.getint("runner", "LISTEN_PORT", fallback=1706))
+)
 
+if args.debug:
+    quart_config.set("runner", "DEBUG", "true")
+    hypercorn_config.loglevel = "debug"
 
-@app.before_request
-async def check_authorized():
-    """
-    Only respond to requests from ALLOWED_IP_RANGE if it's configured in config.ini
-    """
-    if app.runner_config.has_option("runner", "ALLOWED_IP_RANGE"):
-        allowed_ip_range = ip_network(app.runner_config["runner"]["ALLOWED_IP_RANGE"])
-        requesting_ip = ip_address(request.remote_addr)
-        if requesting_ip not in allowed_ip_range:
-            logging.info(
-                "Dropping request from unauthorized host " + request.remote_addr
-            )
-            return jsonify(status="forbidden"), 403
-        else:
-            logging.info("Request from " + request.remote_addr)
-
-
-@app.before_request
-async def check_media_type():
-    """
-    Only respond requests with Content-Type header of application/json
-    """
-    if not request.headers.get("Content-Type").lower().startswith("application/json"):
-        logging.error(
-            '"Content-Type: application/json" header missing from request made by '
-            + request.remote_addr
-        )
-        return jsonify(status="unsupported media type"), 415
-
-
-@app.route("/test", methods=["POST"])
-async def test():
-    logging.debug("Content-Type: " + request.headers.get("Content-Type"))
-    logging.debug(await request.get_json(force=True))
-    return jsonify(status="success", sender=request.remote_addr)
-
-
-if __name__ == "__main__":
-    app.runner_config = ConfigParser()
-    app.runner_config.read("config.ini")
-
-    if args.debug:
-        app.runner_config.set("runner", "DEBUG", "true")
-
-    if app.runner_config.getboolean("runner", "DEBUG", fallback="False") == True:
-        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
-        logging.info("Debug logging is on")
-    else:
-        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
-
-    app.git_protocol = app.runner_config.get("runner", "GIT_PROTOCOL", fallback="http")
-    logging.info("git protocol is " + app.git_protocol)
-
-    logging.info(
-        "Limiting requests to: "
-        + app.runner_config.get("runner", "ALLOWED_IP_RANGE", fallback="<any>")
-    )
-
-    app.git = which("git")
-    app.rsync = which("rsync")
-    app.docker = which("docker")
-    app.tf_bin = which("terraform")
-
-    try:
-        access(app.git, X_OK)
-    except:
-        logging.error("git binary not found or not executable")
-        exit(1)
-    try:
-        access(app.rsync, X_OK)
-    except:
-        logging.error("rsync binary not found or not executable")
-        exit(1)
-    try:
-        access(app.docker, X_OK)
-    except:
-        logging.error("docker binary not found or not executable")
-        exit(1)
-    try:
-        access(app.tf_bin, X_OK)
-    except:
-        logging.error("terraform binary not found or not executable")
-        exit(1)
-
-    if (
-        app.runner_config.getboolean("runner", "GIT_SSL_NO_VERIFY", fallback="False")
-        == True
-    ):
-        environ["GIT_SSL_NO_VERIFY"] = "true"
-    if (
-        app.runner_config.getboolean("runner", "GIT_SSH_NO_VERIFY", fallback="False")
-        == True
-    ):
-        environ[
-            "GIT_SSH_COMMAND"
-        ] = "ssh -o UserKnownHostsFile=test -o StrictHostKeyChecking=no"
-
-    from runner.docker import docker as docker_bp
-    from runner.rsync import rsync as rsync_bp
-    from runner.terraform import terraform as terraform_bp
-
-    app.register_blueprint(docker_bp, url_prefix="/docker")
-    app.register_blueprint(rsync_bp)
-    app.register_blueprint(terraform_bp, url_prefix="/terraform")
-
-
-    app.run(
-        host=app.runner_config.get("runner", "LISTEN_IP", fallback="0.0.0.0"),
-        port=app.runner_config.getint("runner", "LISTEN_PORT", fallback=1706),
-        debug=logging.root.level,
-    )
+asyncio.run(serve(runner.create_app(quart_config), hypercorn_config))


### PR DESCRIPTION
In order to use background tasks in the future, tea-runner is now using:
* [Quart](https://quart.palletsprojects.com/) instead of [Flask](https://flask.palletsprojects.com/).
* [Hypercorn](https://hypercorn.readthedocs.io/) instead of [Waitress](https://docs.pylonsproject.org/projects/waitress/).
* The Quart application is now defined as a module, however the starting script (tea-runner.py) can be use all the same.
